### PR TITLE
fix: remediate vs AWS foundational security baseline

### DIFF
--- a/api_helpers/post-api-helpers.sh
+++ b/api_helpers/post-api-helpers.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
 echo "Executing Baseline Post-API Helpers"
+
+aws iam generate-credential-report

--- a/terraform/account.tf
+++ b/terraform/account.tf
@@ -1,0 +1,59 @@
+resource "aws_account_alternate_contact" "security" {
+
+  alternate_contact_type = "SECURITY"
+
+  name          = data.aws_ssm_parameter.security_contact.value
+  title         = "Director"
+  email_address = data.aws_ssm_parameter.security_email.value
+  phone_number  = data.aws_ssm_parameter.security_phone.value
+}
+
+# We intend to rely on AWS SSO for user management, so
+# we will not create any IAM users or passwords.
+resource "aws_iam_account_password_policy" "strict" {
+  minimum_password_length        = 45
+  require_lowercase_characters   = true
+  require_numbers                = true
+  require_uppercase_characters   = true
+  require_symbols                = true
+  password_reuse_prevention      = 15
+  max_password_age               = 5
+  allow_users_to_change_password = true
+}
+
+resource "aws_ebs_encryption_by_default" "primary_region" {
+  enabled = true
+}
+
+# resource "aws_ebs_encryption_by_default" "backup_region" {
+#   provider = aws.backup
+#   enabled  = true
+# }
+
+# resource "aws_ebs_encryption_by_default" "global_region" {
+#   provider = aws.global
+#   enabled  = true
+# }
+
+resource "aws_s3_account_public_access_block" "strict" {
+  block_public_acls   = true
+  block_public_policy = true
+}
+
+resource "aws_default_security_group" "primary_region" {
+  vpc_id = data.aws_vpc.primary_region.id
+}
+
+# resource "aws_default_security_group" "backup_region" {
+#   provider = aws.backup
+#   vpc_id   = data.aws_vpc.backup_region.id
+# }
+
+data "aws_vpc" "primary_region" {
+  default = true
+}
+
+# data "aws_vpc" "backup_region" {
+#   provider = aws.backup
+#   default  = true
+# }

--- a/terraform/aft-providers.jinja
+++ b/terraform/aft-providers.jinja
@@ -12,3 +12,31 @@ provider "aws" {
     }
   }
 }
+
+# Backup region hard-coded untill AFT supports providing this dynamically i
+# some fashion, see https://github.com/aws-ia/terraform-aws-control_tower_account_factory/issues/264
+# provider "aws" {
+#   alias = "backup"
+#   region = "eu-central-1"
+#   assume_role {
+#     role_arn = "{{ target_admin_role_arn }}"
+#   }
+#   default_tags {
+#     tags = {
+#       managed_by = "AFT"
+#     }
+#   }
+# }
+#
+# provider "aws" {
+#   alias = "global"
+#   region = "us-east-1"
+#   assume_role {
+#     role_arn = "{{ target_admin_role_arn }}"
+#   }
+#   default_tags {
+#     tags = {
+#       managed_by = "AFT"
+#     }
+#   }
+# }

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -1,3 +1,15 @@
+data "aws_ssm_parameter" "security_contact" {
+  name = "/aft/account-request/custom-fields/security-contact"
+}
+
+data "aws_ssm_parameter" "security_email" {
+  name = "/aft/account-request/custom-fields/security-email"
+}
+
+data "aws_ssm_parameter" "security_phone" {
+  name = "/aft/account-request/custom-fields/security-phone"
+}
+
 data "aws_ssm_parameter" "steampipe_cloud" {
   name = "/aft/account-request/custom-fields/steampipe-cloud"
 }


### PR DESCRIPTION
- Alternate Security Contact
- Password Policies 
- Enable EBS Encryption by Default
- Disable Overly Permissive Default Security Group 
- Enable S3 Public Access Block by Default